### PR TITLE
Make signature hash algorithm configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,27 @@ $connector_shared_secret = "your_generated_connector_shared_secret";
 $client = new Client($api_user, $api_password, $connector_api_key, $connector_shared_secret);
 ```
 
+If you want to use `sha512` as hash algorithm for the security signature you can instantiate the client like this:
+
+```php
+<?php
+
+use Ixopay\Client\Client;
+use Ixopay\Client\Data\Customer;
+use Ixopay\Client\Transaction\Debit;
+use Ixopay\Client\Transaction\Result;
+
+// Include the autoloader (if not already done via Composer autoloader)
+require_once('path/to/initClientAutoload.php');
+
+// Instantiate the "Ixopay\Client\Client" with your credentials
+$api_user = "your_username";
+$api_password = "your_username";
+$connector_api_key = "your_chosen_connector_api_key";
+$connector_shared_secret = "your_generated_connector_shared_secret";
+$client = new Client($api_user, $api_password, $connector_api_key, $connector_shared_secret, null, true);
+```
+
 ### Process a debit transaction
 
 Once you instantiated a [client with credentials](#setting-up-credentials),

--- a/src/Client.php
+++ b/src/Client.php
@@ -181,20 +181,27 @@ class Client
     protected $generator;
 
     /**
+     * @var bool
+     */
+    protected $newAlgo = false;
+
+    /**
      * @param string $username
      * @param string $password
      * @param string $apiKey
      * @param string $sharedSecret
      * @param string $language
      * @param bool   $testMode - DEPRECATED
+     * @param bool   $newAlgo
      */
-    public function __construct($username, $password, $apiKey, $sharedSecret, $language = null, $testMode = false) {
+    public function __construct($username, $password, $apiKey, $sharedSecret, $language = null, $testMode = false, $newAlgo = false) {
         $this->username = $username;
         $this->setPassword($password);
         $this->apiKey = $apiKey;
         $this->sharedSecret = $sharedSecret;
         $this->language = $language;
         $this->testMode = $testMode;
+        $this->newAlgo = $newAlgo;
     }
 
 	/**
@@ -694,7 +701,7 @@ class Client
         $curl = new CurlClient();
         $curl ->setCustomHeaders($this->customRequestHeaders)
             ->setCustomCurlOptions($this->customCurlOptions);
-        $curl->signJson($sharedSecret, $url, $jsonBody, $type)
+        $curl->signJson($sharedSecret, $url, $jsonBody, $type, false, $this->newAlgo)
              ->setAuthentication($username, $password);
 
         if($get){


### PR DESCRIPTION
This allows switching from the default (and according to Ixopay docs not recommended) `md5` to `sha512` as hash algorithm in `CurlClient::createSignature()`.