### PR TITLE
Throw a NotSupportedException for not supported transaction types

### DIFF
--- a/src/Exception/NotSupportedException.php
+++ b/src/Exception/NotSupportedException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ixopay\Client\Exception;
+
+final class NotSupportedException extends \Exception
+{
+}

--- a/src/Xml/XmlGenerator.php
+++ b/src/Xml/XmlGenerator.php
@@ -8,6 +8,7 @@ use Ixopay\Client\Data\IbanCustomer;
 use Ixopay\Client\Data\Request;
 use Ixopay\Client\Exception\InvalidValueException;
 use Ixopay\Client\Schedule\ScheduleData;
+use Ixopay\Client\Exception\NotSupportedException;
 use Ixopay\Client\Exception\TypeException;
 use Ixopay\Client\StatusApi\StatusRequestData;
 use Ixopay\Client\Transaction\Base\AbstractTransaction;
@@ -102,8 +103,10 @@ class XmlGenerator {
                     $node = $this->generatePayoutNode($transaction, $method);
                     break;
                 default:
-                    return null;
-                    break;
+                    throw new NotSupportedException(\sprintf(
+                        'Transaction Type %s is not supported',
+                        \substr(\get_class($transaction), \strrpos('\\') + 1)
+                    ));
             }
         }
 


### PR DESCRIPTION
If a not supported transaction type is used with the XML API a `Call to a member function on null` error will be thrown because the `XmlGenerator` returns null in this case, instead of a `DOMElement`.

Since the XML API is not supported with new features, we didn't implement creating a DOM node for the missing `IncrementalAuthorization`, but we throw a `NotSupportedException` now, which can be handled on the caller side.