### PR TITLE
added missing merchant advice code getters and setters

### DIFF
--- a/src/Data/Result/CreditcardData.php
+++ b/src/Data/Result/CreditcardData.php
@@ -115,6 +115,16 @@ class CreditcardData extends ResultData {
     /**
      * @var string
      */
+    protected $merchantAdviceCode;
+
+    /**
+     * @var string
+     */
+    protected $parsedMerchantAdviceCode;
+
+    /**
+     * @var string
+     */
     protected $schemeTransactionIdentifier;
 
     /**
@@ -433,6 +443,42 @@ class CreditcardData extends ResultData {
     /**
      * @return string
      */
+    public function getMerchantAdviceCode()
+    {
+        return $this->merchantAdviceCode;
+    }
+
+    /**
+     * @param string $merchantAdviceCode
+     * @return $this
+     */
+    public function setMerchantAdviceCode($merchantAdviceCode)
+    {
+        $this->merchantAdviceCode = $merchantAdviceCode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParsedMerchantAdviceCode()
+    {
+        return $this->parsedMerchantAdviceCode;
+    }
+
+    /**
+     * @param string $parsedMerchantAdviceCode
+     * @return $this
+     */
+    public function setParsedMerchantAdviceCode($parsedMerchantAdviceCode)
+    {
+        $this->parsedMerchantAdviceCode = $parsedMerchantAdviceCode;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
     public function getSchemeTransactionIdentifier()
     {
         return $this->schemeTransactionIdentifier;
@@ -471,6 +517,8 @@ class CreditcardData extends ResultData {
             // 'firstSixDigits',
             'lastFourDigits',
             'lastName',
+            'merchantAdviceCode',
+            'parsedMerchantAdviceCode',
             'schemeTransactionIdentifier',
             'threeDSecure',
             'type',

--- a/src/Json/JsonParser.php
+++ b/src/Json/JsonParser.php
@@ -370,6 +370,8 @@ class JsonParser {
                 $creditcardData->setBinCountry($this->arrGet($returnData, 'binCountry'));
                 $creditcardData->setThreeDSecure($this->arrGet($returnData, 'threeDSecure'));
                 $creditcardData->setEci($this->arrGet($returnData, 'eci'));
+                $creditcardData->setMerchantAdviceCode($this->arrGet($returnData, 'merchantAdviceCode'));
+                $creditcardData->setParsedMerchantAdviceCode($this->arrGet($returnData, 'parsedMerchantAdviceCode'));
                 $creditcardData->setSchemeTransactionIdentifier($this->arrGet($returnData, 'schemeTransactionIdentifier'));
 
                 if($this->arrGet($returnData, 'binDigits')){


### PR DESCRIPTION
As per documented API response body in
https://documentation.ixopay.com/api/transaction/debit 
and https://documentation.ixopay.com/api/transaction/capture

- added missing merchant advice code values to credit card return data object

